### PR TITLE
New directives and bug fixes

### DIFF
--- a/README
+++ b/README
@@ -205,6 +205,26 @@ Directives
 
     Set the buffer size of Forward Request packet. The range is (0, 2^16).
 
+  ajp_headers_hash_bucket_size
+    syntax: *ajp_headers_hash_bucket_size size;*
+
+    default: *ajp_headers_hash_bucket_size 64;*
+
+    context: *http, server, location*
+
+    Sets the bucket size for hash tables used by the ajp_hide_header and
+    ajp_set_header directives.
+
+  ajp_headers_hash_max_size
+    syntax: *ajp_headers_hash_max_size size;*
+
+    default: *ajp_headers_hash_max_size 512;*
+
+    context: *http, server, location*
+
+    Sets the maximum size of hash tables used by the ajp_hide_header and
+    ajp_set_header directives.
+
   ajp_hide_header
     syntax: *ajp_hide_header name;*
 
@@ -294,6 +314,7 @@ Directives
     transferred to the client -- that is, if an error or timeout arises in
     the middle of the transfer of the request, then it is not possible to
     retry the current request on a different server.
+
   ajp_max_data_packet_size
     syntax: *ajp_max_data_packet_size size;*
 
@@ -403,6 +424,19 @@ Directives
     upstream server will not take new data, then nginx is shutdown the
     connection.
 
+  ajp_set_header
+    syntax: *ajp_set_header name value;*
+
+    context: *http, server, location*
+
+    Allows redefining or appending fields to the request header passed to
+    the AJP server. The value can contain text, variables, and their
+    combinations.
+
+    These directives are inherited from the previous configuration level if
+    and only if there are no ajp_set_header directives defined on the
+    current level.
+
   ajp_store
     syntax: *ajp_store [on | off | path] ;*
 
@@ -502,8 +536,10 @@ Compatibility
     The master branch is for Nginx-1.1.4+
     If you want to use it with Nginx-1.0.x, you can use this nginx-1.0
     (<https://github.com/yaoweibin/nginx_ajp_module/tree/nginx-1.0>) branch.
+
 TODO
     SSL
+
 Known Issues
     *
 
@@ -514,15 +550,18 @@ Changelogs
     bugfix
   v0.1
     first release
+
 Authors
     Weibin Yao(姚伟斌) *yaoweibin AT gmail DOT com*
     Jinti Shen(路奇) *jinti.shen AT gmail DOT com*
     Joshua Zhu(叔度) *zhuzhaoyuan AT gmail DOT com*
     Simon Liu(雕梁) *simohayha.bobo AT gmail DOT com*
     Matthew Ma(东坡) *mj19821214 AT gmail DOT com*
+
 Acknowledgments
     Thanks 李金虎(beagem@163.com) to improve the keepalive feature with
     this module.
+
 License
     This README template is from agentzh (<http://github.com/agentzh>).
 
@@ -543,6 +582,7 @@ License
     Redistributions in binary form must reproduce the above copyright
     notice, this list of conditions and the following disclaimer in the
     documentation and/or other materials provided with the distribution.
+
     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
     IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
     TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A

--- a/README.markdown
+++ b/README.markdown
@@ -178,6 +178,26 @@ __context:__ _http, server, location_
 
 Set the buffer size of Forward Request packet. The range is (0, 2^16).
 
+## ajp\_headers\_hash\_bucket\_size
+
+__syntax:__ _ajp\_headers\_hash\_bucket\_size size;_
+
+__default:__ _ajp\_headers\_hash\_bucket\_size 64;_
+
+__context:__ _http, server, location_
+
+Sets the bucket size for hash tables used by the ajp\_hide\_header and ajp\_set\_header directives.
+
+## ajp\_headers\_hash\_max\_size
+
+__syntax:__ _ajp\_headers\_hash\_max\_size size;_
+
+__default:__ _ajp\_headers\_hash\_max\_size 512;_
+
+__context:__ _http, server, location_
+
+Sets the maximum size of hash tables used by the ajp\_hide\_header and ajp\_set\_header directives.
+
 ## ajp\_hide\_header
 
 __syntax:__ _ajp\_hide\_header name;_
@@ -364,6 +384,16 @@ __context:__ _http, server, location_
 
 This directive assigns timeout with the transfer of request to the upstream server. Timeout is established not on entire transfer of request, but only between two write operations. If after this time the upstream server will not take new data, then nginx is shutdown the connection.
 
+## ajp\_set\_header
+
+__syntax:__ _ajp\_set\_header name value;_
+
+__context:__ _http, server, location_
+
+Allows redefining or appending fields to the request header passed to the AJP server. The value can contain text, variables, and their combinations.
+
+These directives are inherited from the previous configuration level if and only if there are no ajp\_set\_header directives defined on the current level.
+
 ## ajp\_store
 
 __syntax:__ _ajp\_store \[on | off | path\] ;_
@@ -500,11 +530,3 @@ Redistribution and use in source and binary forms, with or without modification,
 - Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# POD ERRORS
-
-Hey! __The above document had some coding errors, which are explained below:__
-
-- Around line 212:
-
-    L<> starts or ends with whitespace

--- a/README.wiki
+++ b/README.wiki
@@ -195,7 +195,7 @@ Parameters of caching can also be set directly in the response header. This has 
 
 This directive assigns a timeout for the connection to the upstream server. It is necessary to keep in mind that this time out cannot be more than 75 seconds.
 
-This is not the time until the server returns the pages, this is the [[#ajp_read_timeout| ajp_read_timeout]]  statement. If your upstream server is up, but hanging (e.g. it does not have enough threads to process your request so it puts you in the pool of connections to deal with later), then this statement will not help as the connection to the server has been made.
+This is not the time until the server returns the pages, this is the [[#ajp_read_timeout|ajp_read_timeout]] statement. If your upstream server is up, but hanging (e.g. it does not have enough threads to process your request so it puts you in the pool of connections to deal with later), then this statement will not help as the connection to the server has been made.
 
 == ajp_header_packet_buffer_size ==
 
@@ -206,6 +206,26 @@ This is not the time until the server returns the pages, this is the [[#ajp_read
 '''context:''' ''http, server, location''
 
 Set the buffer size of Forward Request packet. The range is (0, 2^16).
+
+== ajp_headers_hash_bucket_size ==
+
+'''syntax:''' ''ajp_headers_hash_bucket_size size;''
+
+'''default:''' ''ajp_headers_hash_bucket_size 64;''
+
+'''context:''' ''http, server, location''
+
+Sets the bucket size for hash tables used by the ajp_hide_header and ajp_set_header directives.
+
+== ajp_headers_hash_max_size ==
+
+'''syntax:''' ''ajp_headers_hash_max_size size;''
+
+'''default:''' ''ajp_headers_hash_max_size 512;''
+
+'''context:''' ''http, server, location''
+
+Sets the maximum size of hash tables used by the ajp_hide_header and ajp_set_header directives.
 
 == ajp_hide_header ==
 
@@ -396,6 +416,16 @@ This directive set SO_SNDLOWAT. This directive is only available on FreeBSD
 '''context:''' ''http, server, location''
 
 This directive assigns timeout with the transfer of request to the upstream server. Timeout is established not on entire transfer of request, but only between two write operations. If after this time the upstream server will not take new data, then nginx is shutdown the connection.
+
+== ajp_set_header ==
+
+'''syntax:''' ''ajp_set_header name value;''
+
+'''context:''' ''http, server, location''
+
+Allows redefining or appending fields to the request header passed to the AJP server. The value can contain text, variables, and their combinations.
+
+These directives are inherited from the previous configuration level if and only if there are no ajp_set_header directives defined on the current level.
 
 == ajp_store ==
 

--- a/ngx_http_ajp_handler.c
+++ b/ngx_http_ajp_handler.c
@@ -245,7 +245,7 @@ ngx_http_ajp_create_request(ngx_http_request_t *r)
         cl->next = ajp_data_msg_send_body(r,
                 alcf->max_ajp_data_packet_size_conf, &a->body);
 
-        if (a->body && cl->next) {
+        if (a->body) {
             a->state = ngx_http_ajp_st_request_body_data_sending;
         }
         else {
@@ -500,7 +500,7 @@ ngx_http_upstream_send_request_body(ngx_http_request_t *r,
     a = ngx_http_get_module_ctx(r, ngx_http_ajp_module);
     alcf = ngx_http_get_module_loc_conf(r, ngx_http_ajp_module);
 
-    if (a->state > ngx_http_ajp_st_request_body_data_sending) {
+    if (a->state > ngx_http_ajp_st_request_send_all_done) {
         ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
                       "ngx_http_upstream_send_request_body: bad state(%d)",
                       a->state);
@@ -535,7 +535,7 @@ ngx_http_upstream_send_request_body(ngx_http_request_t *r,
         }
     }
 
-    if (a->body && cl) {
+    if (a->body) {
         a->state = ngx_http_ajp_st_request_body_data_sending;
 
     } else {

--- a/ngx_http_ajp_handler.c
+++ b/ngx_http_ajp_handler.c
@@ -245,7 +245,7 @@ ngx_http_ajp_create_request(ngx_http_request_t *r)
         cl->next = ajp_data_msg_send_body(r,
                 alcf->max_ajp_data_packet_size_conf, &a->body);
 
-        if (a->body) {
+        if (a->body && cl->next) {
             a->state = ngx_http_ajp_st_request_body_data_sending;
         }
         else {
@@ -535,7 +535,7 @@ ngx_http_upstream_send_request_body(ngx_http_request_t *r,
         }
     }
 
-    if (a->body) {
+    if (a->body && cl) {
         a->state = ngx_http_ajp_st_request_body_data_sending;
 
     } else {

--- a/ngx_http_ajp_module.h
+++ b/ngx_http_ajp_module.h
@@ -14,6 +14,13 @@ typedef struct {
 #endif
 
 typedef struct {
+    ngx_array_t                   *flushes;
+    ngx_array_t                   *lengths;
+    ngx_array_t                   *values;
+    ngx_hash_t                     hash;
+} ngx_ajp_proxy_headers_t;
+
+typedef struct {
     ngx_http_upstream_conf_t   upstream;
 
     size_t                     ajp_header_packet_buffer_size_conf;
@@ -31,6 +38,14 @@ typedef struct {
 #endif
 
     ngx_str_t		       secret;
+
+    ngx_ajp_proxy_headers_t        headers;
+#if (NGX_HTTP_CACHE)
+    ngx_ajp_proxy_headers_t        headers_cache;
+#endif
+    ngx_array_t                   *headers_source;
+    ngx_uint_t                     headers_hash_max_size;
+    ngx_uint_t                     headers_hash_bucket_size;
 
 } ngx_http_ajp_loc_conf_t;
 

--- a/util/pod2markdown.pl
+++ b/util/pod2markdown.pl
@@ -22,6 +22,7 @@ use strict;
 use warnings;
 use Pod::Parser; 
 use Pod::Markdown;
+use open qw( :std :encoding(UTF-8) );
 
 my $parser = Pod::Markdown->new;
 


### PR DESCRIPTION
Implement "ajp_set_header", "ajp_headers_hash_max_size", "ajp_headers_hash_bucket_size" directives (backport of respective "proxy_..." directives from ngx_http_proxy_module).

Fix empty request body marker always sent even if client request does not have a body, rendering malformed AJP request.

Fix wrong header value used in the "Route" AJP request attribute instead of "Session-Route" one.

Fix authentication type value length miscalculation causing "Auth-Type" request attribute missing trailing character.

Fix markdown converter unicode output warning.